### PR TITLE
ci: fix missing POM_ARTIFACT_ID

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: ./gradlew assemble --stacktrace
 
       - name: Run Bucketeer unit tests
-        run: ./gradlew :bucketeer:testDebugUnitTest --stacktrace
+        run: ./gradlew :openfeatureprovider:testDebugUnitTest --stacktrace
 
       - name: upload bucketeer build reports
         if: always()

--- a/openfeatureprovider/gradle.properties
+++ b/openfeatureprovider/gradle.properties
@@ -1,4 +1,4 @@
-POM_ARTIFACT_ID=openfeatureprovider
+POM_ARTIFACT_ID=openfeature-kotlin-client-sdk
 POM_NAME=Bucketeer OpenFeature Kotlin provider
 POM_DESCRIPTION=Bucketeer OpenFeature Kotlin provider for Android clients
 POM_PACKAGING=aar

--- a/openfeatureprovider/gradle.properties
+++ b/openfeatureprovider/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=openfeatureprovider
+POM_NAME=Bucketeer OpenFeature Kotlin provider
+POM_DESCRIPTION=Bucketeer OpenFeature Kotlin provider for Android clients
+POM_PACKAGING=aar

--- a/openfeatureprovider/proguard-rules.pro
+++ b/openfeatureprovider/proguard-rules.pro
@@ -1,21 +1,4 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-keep class io.bucketeer.sdk.android.internal.model.** { *; }


### PR DESCRIPTION
## Changes
### Build workflow updates:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L37-R37): Updated the unit test command to run tests for the `openfeatureprovider` module instead of `bucketeer`.

### OpenFeature provider configuration:
* [`openfeatureprovider/gradle.properties`](diffhunk://#diff-a8cc9d027c2b4923d91233b34db8bffb94bb9e70b89c423e9c790e5482e37f23R1-R4): Added metadata for the OpenFeature Kotlin provider, including artifact ID, name, description, and packaging type.

### ProGuard rules refinement:
* [`openfeatureprovider/proguard-rules.pro`](diffhunk://#diff-5bb82f373e9e24a30956ddbc30085a5961f40b86d4ba5807923d4c564eb7fcf2L1-R4): Replaced generic placeholder rules with specific rules for handling JSR 305 annotations and preserving classes in the `io.bucketeer.sdk.android.internal.model` package.This pull request introduces configurations and optimizations for the OpenFeature Kotlin provider. The most important changes include adding metadata to `gradle.properties` and updating ProGuard rules to improve compatibility and reduce warnings.

### Metadata configuration:
* [`openfeatureprovider/gradle.properties`](diffhunk://#diff-a8cc9d027c2b4923d91233b34db8bffb94bb9e70b89c423e9c790e5482e37f23R1-R4): Added metadata properties (`POM_ARTIFACT_ID`, `POM_NAME`, `POM_DESCRIPTION`, and `POM_PACKAGING`) to define the artifact details for the OpenFeature Kotlin provider.

### ProGuard rule updates:
* [`openfeatureprovider/proguard-rules.pro`](diffhunk://#diff-5bb82f373e9e24a30956ddbc30085a5961f40b86d4ba5807923d4c564eb7fcf2L1-R4): Replaced the default ProGuard rules with custom rules to suppress warnings related to JSR 305 annotations and to keep all classes in `io.bucketeer.sdk.android.internal.model`. Removed unused and commented-out default rules for a cleaner configuration.