### PR TITLE
chore(example): use bucketeer provider from maven central

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
     alias(libs.plugins.kotlinter)
 }
 
-val properties = Properties()
+val customProperties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
-    properties.load(localPropertiesFile.inputStream())
+    customProperties.load(localPropertiesFile.inputStream())
 }
 
 android {
@@ -25,8 +25,8 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        val apiKey = properties.getProperty("api_key") ?: System.getenv("API_KEY")
-        val apiEndpoint = properties.getProperty("api_endpoint") ?: System.getenv("API_ENDPOINT")
+        val apiKey = customProperties.getProperty("api_key") ?: System.getenv("API_KEY")
+        val apiEndpoint = customProperties.getProperty("api_endpoint") ?: System.getenv("API_ENDPOINT")
         buildConfigField("String", "API_KEY", "\"${apiKey}\"")
         buildConfigField("String", "API_ENDPOINT", "\"${apiEndpoint}\"")
     }
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.kotlin.coroutines.android)
-
-    implementation(project(":openfeatureprovider"))
+    // Uncomment the following line if you want to use the local OpenFeature provider module
+    //implementation(project(":openfeatureprovider"))
+    implementation(libs.bucketeer.openfeature.kotlin)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,10 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 coroutines = "1.10.1"
+openfeatureKotlinClientSdk = "0.0.1"
 
 [libraries]
+bucketeer-openfeature-kotlin = { module = "io.bucketeer:openfeature-kotlin-client-sdk", version.ref = "openfeatureKotlinClientSdk" }
 bucketeer-android-sdk = { module = "io.bucketeer:android-client-sdk", version.ref = "bucketeerAndroidClientSdk" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "coreKtxVersion" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }

--- a/openfeatureprovider/build.gradle.kts
+++ b/openfeatureprovider/build.gradle.kts
@@ -8,10 +8,10 @@ plugins {
     alias(libs.plugins.kotlinter)
 }
 
-val properties = Properties()
+val customProperties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
-    properties.load(localPropertiesFile.inputStream())
+    customProperties.load(localPropertiesFile.inputStream())
 }
 
 android {
@@ -24,8 +24,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 
-        val apiKey = properties.getProperty("api_key") ?: System.getenv("API_KEY")
-        val apiEndpoint = properties.getProperty("api_endpoint") ?: System.getenv("API_ENDPOINT")
+        val apiKey = customProperties.getProperty("api_key") ?: System.getenv("API_KEY")
+        val apiEndpoint = customProperties.getProperty("api_endpoint") ?: System.getenv("API_ENDPOINT")
         val versionName = project.properties["VERSION_NAME"].toString()
         buildConfigField("String", "API_KEY", "\"${apiKey}\"")
         buildConfigField("String", "API_ENDPOINT", "\"${apiEndpoint}\"")


### PR DESCRIPTION
This pull request introduces changes to improve property management, update dependencies, and enhance modularity in the build configuration. The key updates include renaming the `properties` variable for clarity, adding a new dependency for the OpenFeature Kotlin client SDK, and commenting out an unused local module dependency.

### Property Management Updates:
* Renamed the `properties` variable to `customProperties` for better clarity and consistency in both `app/build.gradle.kts` and `openfeatureprovider/build.gradle.kts`. This change impacts loading and accessing properties like `api_key` and `api_endpoint`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L9-R12) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L28-R29) [[3]](diffhunk://#diff-7f8829af28286183973c01624cbca369eabbf7cfbd248a0cde14e5ad9042f02bL11-R14) [[4]](diffhunk://#diff-7f8829af28286183973c01624cbca369eabbf7cfbd248a0cde14e5ad9042f02bL27-R28)

### Dependency Updates:
* Added a new dependency for `bucketeer-openfeature-kotlin` in `gradle/libs.versions.toml` and updated its version reference to `openfeatureKotlinClientSdk`. This enables integration with the OpenFeature Kotlin client SDK.
* Updated `app/build.gradle.kts` to include `libs.bucketeer.openfeature.kotlin` while commenting out the local `openfeatureprovider` module dependency for optional use.