### PR TITLE
ci: replace classic pat with github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@fb7f385da2046f35c544011bc27c9f809122ad2c # v4.2.0
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }} # We need to set the PAT so the publish workflow can be triggered
+          token: ${{ steps.app-token.outputs.token }} # App token so the tag/release created by release-please can trigger other workflows


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/2703

Replaces the classic PATs (WORKFLOW_TOKEN, REPO_ACCESS_PAT) with short-lived installation tokens minted from a GitHub App via actions/create-github-app-token, as part of removing classic PATs from CI. The app token still allows the tag/release created by release-please to trigger the publish workflows.